### PR TITLE
Change default filetypes that trigger the extension.

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,14 +21,15 @@
           "type": "array",
           "default": [
             "asciidoc",
-            "git-commit",
-            "git-rebase",
+            "gitcommit",
+            "gitrebase",
             "json",
             "tex",
+            "plaintex",
+            "context",
             "markdown",
-            "mdx",
-            "plaintext",
-            "restructuredtext"
+            "text",
+            "rst"
           ]
         },
         "grammarly.autoActivate": {


### PR DESCRIPTION
The file types registered by default were different from the ones specified in [`filetype.vim`](https://github.com/vim/vim/blob/master/runtime/filetype.vim), so I changed them. In particular, for `.tex` files, Vim may assign three different file types depending on their contents, so I enabled the extension to work for them as well.