### PR TITLE
Register  an empty callback  for $/updateDocumentState

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -27,5 +27,10 @@ export async function activate(context: ExtensionContext): Promise<void> {
     serverOptions,
     clientOptions
   )
+
+  client.onReady().then(() => {
+    client.onRequest("$/updateDocumentState", () => {})
+  })
+
   context.subscriptions.push(services.registLanguageClient(client))
 }


### PR DESCRIPTION
This is something I learned reading

https://github.com/emacs-grammarly/lsp-grammarly/issues/5

Fixed #15
